### PR TITLE
Update bartlett version

### DIFF
--- a/bartlett.rb
+++ b/bartlett.rb
@@ -2,8 +2,8 @@ class Bartlett < Formula
 
   desc "A simple Jenkins command line client to serve your needs."
   homepage "https://github.com/Nike-Inc/bartlett"
-  url "https://github.com/Nike-Inc/bartlett/releases/download/1.5.1/bartlett-static-1.5.1.tar.gz"
-  sha256 "3d46b4813914df07071bf2314d8e8df09a5c849c80827f33a16174de6cad1d50"
+  url "https://github.com/Nike-Inc/bartlett/releases/download/1.6.0/bartlett-static-1.6.0.tar.gz"
+  sha256 "d6b2260d774a3b84654b22cacf772bdaeeed1125724e4c818edaffa27957b1cb"
 
   def install
     bin.install "bartlett"


### PR DESCRIPTION
Maps to [this release](https://github.com/Nike-Inc/bartlett/releases/tag/1.6.0).